### PR TITLE
fix: remove CommonJS exports for GAS

### DIFF
--- a/DynamicSheetsReporter/build/emit-gas.js
+++ b/DynamicSheetsReporter/build/emit-gas.js
@@ -14,6 +14,11 @@ const OUT = path.join(ROOT, 'out');
 const DIST = path.join(ROOT, 'dist');
 const SRC = path.join(ROOT, 'src');
 
+// Matches CommonJS __esModule declarations such as
+// Object.defineProperty(exports, "__esModule", ({ value: true }));
+// The object literal may optionally be wrapped in parentheses.
+const ES_MODULE_REGEX = /^\s*Object\.defineProperty\(exports?,\s*["']__esModule["']\s*,\s*\(?\{\s*value:\s*true\s*\}\)?\);\s*$/gm;
+
 function ensureDir(p) {
   if (!fs.existsSync(p)) fs.mkdirSync(p, { recursive: true });
 }
@@ -56,7 +61,7 @@ function copyServerJsAsGs() {
       .replace(/^\s*var\s+__webpack_exports__\s*=\s*\{\s*\};\s*$/m, '')
       .replace(/^\s*\/\/\s*This entry needs to be wrapped.*$/m, '')
       // remove any "Object.defineProperty(exports,__esModule...)" that might still linger
-      .replace(/^\s*Object\.defineProperty\(exports?,\s*["']__esModule["']\s*,\s*\{\s*value:\s*true\s*\}\);\s*$/gm, '');
+      .replace(ES_MODULE_REGEX, '');
 
     // 2) Strip TS 'export ' keywords (idempotent)
     transformed = transformed.replace(/\bexport\s+/g, '');
@@ -65,7 +70,7 @@ function copyServerJsAsGs() {
     //    Be aggressive: the line can appear with leading/trailing spaces or comments.
     transformed = transformed
       // kill Object.defineProperty(exports,"__esModule",...)
-      .replace(/^\s*Object\.defineProperty\(exports?,\s*["']__esModule["']\s*,\s*\{\s*value:\s*true\s*\}\);\s*$/gm, '')
+      .replace(ES_MODULE_REGEX, '')
       // kill any "exports.name = name;" style lines
       .replace(/^\s*exports\.[A-Za-z0-9_$]+\s*=\s*[A-Za-z0-9_$]+\s*;\s*$/gm, '')
       // kill "module.exports = ..."

--- a/DynamicSheetsReporter/dist/Code.gs
+++ b/DynamicSheetsReporter/dist/Code.gs
@@ -10,7 +10,6 @@
 
 // LoggingService: structured logging with trace IDs for GAS environment
 // Transpiled to .gs and executed in Apps Script.
-Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function randomId_() {
     const chars = '0123456789abcdef';
@@ -77,7 +76,6 @@ function withTrace(traceId) {
 // Core GAS entry points and user settings handlers
 // Note: Transpiled to .gs and executed in Apps Script environment (V8)
 // Local TypeScript build will not have GAS ambient types; define minimal shims to satisfy TS.
-Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 
 

--- a/DynamicSheetsReporter/dist/GeminiService.gs
+++ b/DynamicSheetsReporter/dist/GeminiService.gs
@@ -9,7 +9,6 @@
 // - 認証は Authorization: Bearer <API_KEY>
 // - モデル: gemini-2.5-pro / gemini-2.5-flash / gemini-2.5-flash-lite
 // - 429/5xx は指数バックオフで再試行
-Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 const PROP_NS = 'DSR';
 const PROP_API_KEY = `${PROP_NS}_GEMINI_API_KEY`;

--- a/DynamicSheetsReporter/dist/SharedTypes.gs
+++ b/DynamicSheetsReporter/dist/SharedTypes.gs
@@ -3,5 +3,3 @@
 /*!*****************************!*\
   !*** ./src/shared/types.ts ***!
   \*****************************/
-
-Object.defineProperty(exports, "__esModule", ({ value: true }));

--- a/DynamicSheetsReporter/dist/SheetsService.gs
+++ b/DynamicSheetsReporter/dist/SheetsService.gs
@@ -6,7 +6,6 @@
 
 // SheetsService: 将来の構造化クエリやエクスポート処理の入口（最小スタブ）
 // .gs 化後にGASで実行されます。現時点では疎通確認用の簡易APIのみ。
-Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function whoAmI() {
     try {

--- a/DynamicSheetsReporter/dist/Validation.gs
+++ b/DynamicSheetsReporter/dist/Validation.gs
@@ -6,7 +6,6 @@
 
 // 最小のバリデーションスタブ（将来拡張予定）
 // Apps Script 互換の単純関数群。TypeScriptで定義し .gs に変換されます。
-Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 
 


### PR DESCRIPTION
## Summary
- strip `Object.defineProperty(...__esModule...)` from generated server files
- rebuild dist so Apps Script no longer sees `exports` references

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6895a767b67483229d25a07bc5d8f202