### PR TITLE
fix: remove CommonJS exports for GAS

### DIFF
--- a/DynamicSheetsReporter/dist/Code.gs
+++ b/DynamicSheetsReporter/dist/Code.gs
@@ -1,89 +1,7 @@
-/******/ 	"use strict";
-/******/ 	var __webpack_modules__ = ({
-
-/***/ "./src/server/LoggingService.ts":
-/*!**************************************!*\
-  !*** ./src/server/LoggingService.ts ***!
-  \**************************************/
-/***/ ((__unused_webpack_module, exports) => {
-
-
-// LoggingService: structured logging with trace IDs for GAS environment
-// Transpiled to .gs and executed in Apps Script.
-Object.defineProperty(exports, "__esModule", ({ value: true }));
-
-function randomId_() {
-    const chars = '0123456789abcdef';
-    let id = '';
-    for (let i = 0; i < 16; i++)
-        id += chars[Math.floor(Math.random() * chars.length)];
-    return id;
-}
-function log_(severity, traceId, message, data) {
-    const entry = {
-        severity,
-        traceId,
-        message,
-        timestamp: new Date().toISOString(),
-    };
-    if (data !== undefined)
-        entry.data = data;
-    console.log(JSON.stringify(entry));
-}
-function withTrace(traceId) {
-    const id = traceId || randomId_();
-    return {
-        traceId: id,
-        info: (message, data) => log_('INFO', id, message, data),
-        error: (message, data) => log_('ERROR', id, message, data),
-    };
-}
-
-
-/***/ })
-
-/******/ 	});
-/************************************************************************/
-/******/ 	// The module cache
-/******/ 	var __webpack_module_cache__ = {};
-/******/ 	
-/******/ 	// The require function
-/******/ 	function __webpack_require__(moduleId) {
-/******/ 		// Check if module is in cache
-/******/ 		var cachedModule = __webpack_module_cache__[moduleId];
-/******/ 		if (cachedModule !== undefined) {
-/******/ 			return cachedModule.exports;
-/******/ 		}
-/******/ 		// Create a new module (and put it into the cache)
-/******/ 		var module = __webpack_module_cache__[moduleId] = {
-/******/ 			// no module.id needed
-/******/ 			// no module.loaded needed
-/******/ 			exports: {}
-/******/ 		};
-/******/ 	
-/******/ 		// Execute the module function
-/******/ 		__webpack_modules__[moduleId](module, module.exports, __webpack_require__);
-/******/ 	
-/******/ 		// Return the exports of the module
-/******/ 		return module.exports;
-/******/ 	}
-/******/ 	
-/************************************************************************/
-
-/*!****************************!*\
-  !*** ./src/server/Code.ts ***!
-  \****************************/
-
 // Core GAS entry points and user settings handlers
 // Note: Transpiled to .gs and executed in Apps Script environment (V8)
 // Local TypeScript build will not have GAS ambient types; define minimal shims to satisfy TS.
-Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-
-
-
-
-const LoggingService_1 = __webpack_require__(/*! ./LoggingService */ "./src/server/LoggingService.ts");
 /* ============================================================= */
 // Constants
 const PROP_NS = 'DSR';
@@ -148,7 +66,7 @@ function saveUserSettings(req) {
 }
 // Minimal ping to verify backend reachable
 function ping() {
-    const logger = (0, LoggingService_1.withTrace)();
+    const logger = (0, withTrace)();
     logger.info('ping');
     return 'pong';
 }

--- a/DynamicSheetsReporter/dist/GeminiService.gs
+++ b/DynamicSheetsReporter/dist/GeminiService.gs
@@ -1,15 +1,8 @@
-/******/ 	"use strict";
-
-/*!*************************************!*\
-  !*** ./src/server/GeminiService.ts ***!
-  \*************************************/
-
 // GeminiService: Google AI Studio v1beta generateContent 呼び出し（Apps Script UrlFetchApp）
 // 注意: ここは .gs に変換され、GAS 環境で実行されます。
 // - 認証は Authorization: Bearer <API_KEY>
 // - モデル: gemini-2.5-pro / gemini-2.5-flash / gemini-2.5-flash-lite
 // - 429/5xx は指数バックオフで再試行
-Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 const PROP_NS = 'DSR';
 const PROP_API_KEY = `${PROP_NS}_GEMINI_API_KEY`;

--- a/DynamicSheetsReporter/dist/LoggingService.gs
+++ b/DynamicSheetsReporter/dist/LoggingService.gs
@@ -1,0 +1,29 @@
+// LoggingService: structured logging with trace IDs for GAS environment
+// Transpiled to .gs and executed in Apps Script.
+
+function randomId_() {
+    const chars = '0123456789abcdef';
+    let id = '';
+    for (let i = 0; i < 16; i++)
+        id += chars[Math.floor(Math.random() * chars.length)];
+    return id;
+}
+function log_(severity, traceId, message, data) {
+    const entry = {
+        severity,
+        traceId,
+        message,
+        timestamp: new Date().toISOString(),
+    };
+    if (data !== undefined)
+        entry.data = data;
+    console.log(JSON.stringify(entry));
+}
+function withTrace(traceId) {
+    const id = traceId || randomId_();
+    return {
+        traceId: id,
+        info: (message, data) => log_('INFO', id, message, data),
+        error: (message, data) => log_('ERROR', id, message, data),
+    };
+}

--- a/DynamicSheetsReporter/dist/SharedTypes.gs
+++ b/DynamicSheetsReporter/dist/SharedTypes.gs
@@ -1,7 +1,0 @@
-/******/ 	"use strict";
-
-/*!*****************************!*\
-  !*** ./src/shared/types.ts ***!
-  \*****************************/
-
-Object.defineProperty(exports, "__esModule", ({ value: true }));

--- a/DynamicSheetsReporter/dist/SheetsService.gs
+++ b/DynamicSheetsReporter/dist/SheetsService.gs
@@ -1,12 +1,5 @@
-/******/ 	"use strict";
-
-/*!*************************************!*\
-  !*** ./src/server/SheetsService.ts ***!
-  \*************************************/
-
 // SheetsService: 将来の構造化クエリやエクスポート処理の入口（最小スタブ）
 // .gs 化後にGASで実行されます。現時点では疎通確認用の簡易APIのみ。
-Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function whoAmI() {
     try {

--- a/DynamicSheetsReporter/dist/Validation.gs
+++ b/DynamicSheetsReporter/dist/Validation.gs
@@ -1,12 +1,5 @@
-/******/ 	"use strict";
-
-/*!**********************************!*\
-  !*** ./src/shared/validation.ts ***!
-  \**********************************/
-
 // 最小のバリデーションスタブ（将来拡張予定）
 // Apps Script 互換の単純関数群。TypeScriptで定義し .gs に変換されます。
-Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 
 


### PR DESCRIPTION
## Summary
- transpile server TypeScript directly to `.gs` files and strip CommonJS wrappers
- expose `withTrace` via new `LoggingService.gs` and update `Code.gs` to call it without `exports`

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895a767b67483229d25a07bc5d8f202